### PR TITLE
Add Hot Reload to PreviewFrame #5

### DIFF
--- a/BlazingStory/Internals/Components/Preview/PreviewFrame.razor
+++ b/BlazingStory/Internals/Components/Preview/PreviewFrame.razor
@@ -2,7 +2,7 @@
 @inject IJSRuntime JSRuntime
 
 <div class="preview-frame">
-    <iframe id="@this._IframeElementId" @ref="_Iframe" src="@_InitialPreviewFrameUrl"></iframe>
+    <iframe id="@this._IframeElementId" @ref="_Iframe" src="@_InitialPreviewFrameUrl" @onload="OnPreviewIFrameLoaded"></iframe>
 </div>
 
 @code
@@ -34,7 +34,9 @@
 
     private readonly JSModule _JSModule;
 
-    private bool _AfterFirstRenderd = false;
+    private bool _AfterFirstRendered = false;
+
+    private bool _IsHotReloadEnabled = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PreviewFrame"/> class.
@@ -44,8 +46,9 @@
         this._JSModule = new(() => this.JSRuntime, "Internals/Components/Preview/PreviewFrame.razor.js");
     }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        this._IsHotReloadEnabled = await this.IsHotReloadEnabled();
         this._InitialPreviewFrameUrl = this._CurrentPreviewFrameUrl = this.GetPreviewFrameUrl();
     }
 
@@ -54,20 +57,28 @@
         await this.UpdatePreviewFrameUrlAsync();
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
         this.StateHasChanged();
-        this._AfterFirstRenderd = true;
+        this._AfterFirstRendered = true;
     }
 
     private async ValueTask UpdatePreviewFrameUrlAsync()
     {
-        if (!this._AfterFirstRenderd) return;
+        if (!this._AfterFirstRendered) return;
         var nextPreviewFrameUrl = this.GetPreviewFrameUrl();
         if (this._CurrentPreviewFrameUrl == nextPreviewFrameUrl) return;
         this._CurrentPreviewFrameUrl = nextPreviewFrameUrl;
         await _JSModule.InvokeVoidAsync("navigatePreviewFrameTo", this._Iframe, nextPreviewFrameUrl);
+    }
+    
+    private async Task OnPreviewIFrameLoaded(ProgressEventArgs obj)
+    {
+        if (_IsHotReloadEnabled)
+        {
+            await EnsureDotnetWatchScriptInjected();
+        }
     }
 
     private string GetPreviewFrameUrl()
@@ -102,6 +113,16 @@
     internal async ValueTask ResetZoomAsync()
     {
         await this._JSModule.InvokeVoidAsync("resetZoomPreviewFrame", this._Iframe);
+    }
+
+    private async ValueTask EnsureDotnetWatchScriptInjected()
+    {
+        await this._JSModule.InvokeVoidAsync("ensureDotnetWatchScriptInjected", this._Iframe);
+    }
+
+    private async ValueTask<bool> IsHotReloadEnabled()
+    {
+        return await this._JSModule.InvokeAsync<bool>("isHotReloadEnabled");
     }
 
     public async ValueTask DisposeAsync()

--- a/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.js
+++ b/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.js
@@ -44,6 +44,23 @@ const zoomPreviewFrame = (iframe, getNextZoomLevel) => {
     const nextZoomLevel = getNextZoomLevel(currentZoomLevel);
     style.zoom = '' + nextZoomLevel;
 };
+const isDotnetWatchScriptInjected = (window) => {
+    var _a;
+    const scriptInjectedSentinel = '_dotnet_watch_ws_injected';
+    return (_a = window === null || window === void 0 ? void 0 : window.hasOwnProperty(scriptInjectedSentinel)) !== null && _a !== void 0 ? _a : false;
+};
+export const isHotReloadEnabled = () => {
+    return isDotnetWatchScriptInjected(window);
+};
+export const ensureDotnetWatchScriptInjected = (iframe) => {
+    if (iframe === null || iframe.contentWindow == null || iframe.contentDocument == null)
+        return;
+    if (isDotnetWatchScriptInjected(iframe.contentWindow))
+        return;
+    const script = iframe.contentDocument.createElement('script');
+    script.src = '_framework/aspnetcore-browser-refresh.js';
+    iframe.contentDocument.body.appendChild(script);
+};
 export const zoomInPreviewFrame = (iframe) => zoomPreviewFrame(iframe, zoom => zoom * 1.25);
 export const zoomOutPreviewFrame = (iframe) => zoomPreviewFrame(iframe, zoom => zoom / 1.25);
 export const resetZoomPreviewFrame = (iframe) => zoomPreviewFrame(iframe, _ => 1);

--- a/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.ts
+++ b/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.ts
@@ -43,6 +43,30 @@ const zoomPreviewFrame = (iframe: HTMLIFrameElement | null, getNextZoomLevel: (z
     style.zoom = '' + nextZoomLevel;
 }
 
+// Checks the '_dotnet_watch_ws_injected' property has been added to the window object,
+// indicating that the '_framework/aspnetcore-browser-refresh.js' script has been loaded.
+// see: https://github.com/dotnet/sdk/blob/12c083fc90700d3255cc021b665764876c5747fe/src/BuiltInTools/BrowserRefresh/WebSocketScriptInjection.js#L4
+const isDotnetWatchScriptInjected = (window: Window | null):boolean => {
+    const scriptInjectedSentinel = '_dotnet_watch_ws_injected';
+    return window?.hasOwnProperty(scriptInjectedSentinel) ?? false;
+}
+
+// Checks if hot reload is enabled by verifying if the dotnet watch script is injected in the current window.
+export const isHotReloadEnabled = ():boolean => {
+    return isDotnetWatchScriptInjected(window);
+}
+
+export const ensureDotnetWatchScriptInjected = (iframe: HTMLIFrameElement | null):void => {
+    if (iframe === null || iframe.contentWindow == null || iframe.contentDocument == null) return;
+    if (isDotnetWatchScriptInjected(iframe.contentWindow)) 
+        return; // Already injected
+
+    const script = iframe.contentDocument!.createElement('script');
+    script.src = '_framework/aspnetcore-browser-refresh.js';
+    iframe.contentDocument!.body.appendChild(script);
+}
+
+
 export const zoomInPreviewFrame = (iframe: HTMLIFrameElement | null) => zoomPreviewFrame(iframe, zoom => zoom * 1.25);
 
 export const zoomOutPreviewFrame = (iframe: HTMLIFrameElement | null) => zoomPreviewFrame(iframe, zoom => zoom / 1.25);


### PR DESCRIPTION
This merge request addresses an issue where hot reload doesn't work within PreviewFrames.

The BrowserRefresh Middleware in the dotnet SDK will only inject aspnetcore-browser-refresh.js when the "Sec-Fetch-Dest" header is set to "document". This was intentionally done to block the hot reload from occurring within iframes.
- https://github.com/dotnet/sdk/blob/main/src/BuiltInTools/BrowserRefresh/BrowserRefreshMiddleware.cs#L70
- https://github.com/dotnet/sdk/pull/21954

This merge request will just inject the script from the parent when the Iframe has loaded.

The sample project is still having hot-reload issues that my own demo project is not having. 
The error is: 
EnC: we do not support patching of existing table cols.

Once I get some more time I'll investigate why this is happening.