### PR TITLE
Wrap items when there are many so the design does not break

### DIFF
--- a/BlazingStory/Internals/Pages/Canvas/Controls/ControlsPanel.razor.scss
+++ b/BlazingStory/Internals/Pages/Canvas/Controls/ControlsPanel.razor.scss
@@ -57,7 +57,7 @@
 
                 & > .parameter-type-holder {
                     display: flex;
-                    flex-wrap:wrap;
+                    flex-wrap: wrap;
                     gap: 4px;
                     margin-top: 4px;
 

--- a/BlazingStory/Internals/Pages/Canvas/Controls/ControlsPanel.razor.scss
+++ b/BlazingStory/Internals/Pages/Canvas/Controls/ControlsPanel.razor.scss
@@ -57,6 +57,7 @@
 
                 & > .parameter-type-holder {
                     display: flex;
+                    flex-wrap:wrap;
                     gap: 4px;
                     margin-top: 4px;
 


### PR DESCRIPTION
Added flex: wrap to .parameter-type-holder since it grew to much and made the layout "overflow".

Previous look with many items in the description field.
![image](https://github.com/jsakamoto/BlazingStory/assets/20942566/ee88687e-7bfd-4336-af07-58de78afd273)

Now
![image](https://github.com/jsakamoto/BlazingStory/assets/20942566/76265e19-2868-47f6-b23e-220dfaceb5b2)
