### PR TITLE
Fix Unhandled Exceptions and Unsupported Serialization in EventTArgMonitorHandler

### DIFF
--- a/BlazingStory/Internals/Pages/Canvas/CanvasFrame.razor
+++ b/BlazingStory/Internals/Pages/Canvas/CanvasFrame.razor
@@ -3,6 +3,7 @@
 @using System.Reflection
 @using System.Linq.Expressions
 @using System.Text.Json
+@using System.Text.Json.Serialization
 @using static System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
 
 @implements IAsyncDisposable
@@ -217,7 +218,12 @@ else
     private async Task EventTArgMonitorHandler<[DynamicallyAccessedMembers(All)] TArgs>(string name, TArgs eventArgs)
     {
 #pragma warning disable IL2026
-        var json = JsonSerializer.Serialize(eventArgs, new JsonSerializerOptions { WriteIndented = true });
+        var json = JsonSerializer.Serialize(eventArgs, new JsonSerializerOptions 
+        { 
+            WriteIndented = true, 
+            ReferenceHandler = ReferenceHandler.Preserve,
+            Converters = { new RenderFragmentJsonConverter(), new ActionJsonConverter() }
+        });
 #pragma warning restore IL2026
         await _JSModule.InvokeVoidAsync("dispatchComponentActionEvent", name, json);
     }

--- a/BlazingStory/Internals/Utils/ActionJsonConverter.cs
+++ b/BlazingStory/Internals/Utils/ActionJsonConverter.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BlazingStory.Internals.Utils;
+public class ActionJsonConverter : JsonConverter<Action>
+{
+    public override Action Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotSupportedException("Deserialization of System.Action is not supported.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, Action value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue("RenderFragment System.Action is not supported.");
+    }
+}

--- a/BlazingStory/Internals/Utils/RenderFragmentJsonConverter.cs
+++ b/BlazingStory/Internals/Utils/RenderFragmentJsonConverter.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazingStory.Internals.Utils;
+public class RenderFragmentJsonConverter : JsonConverter<RenderFragment>
+{
+    public override RenderFragment Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotSupportedException("Deserialization of RenderFragment is not supported.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, RenderFragment value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue("RenderFragment serialization is not supported.");
+    }
+}


### PR DESCRIPTION
#### Summary
Fix for https://github.com/jsakamoto/BlazingStory/issues/65
This PR addresses issues with unhandled exceptions and unsupported serialization in the Event Monitor when using non-serializable types and circular references. The fixes include adding custom JSON converters and handling circular references.

#### Fixes
1. **Event Monitor Serialization Issue**:
   - Added custom JSON converters for `RenderFragment` and `System.Action` to prevent serialization exceptions.
   - Updated `EventTArgMonitorHandler` to use these converters.

2. **Unhandled Exception for Object Cycle**:
   - Added `ReferenceHandler.Preserve` to `JsonSerializerOptions` to handle circular references.

#### Testing
- Added a minimal reproducible sample to verify the fix:
  - **Component**:
    ```csharp name=SerializeComponent.razor
    @namespace RazorClassLib1.Components.SerializeTest
    <div style="background-color: bisque;" @onmouseover="HandleMouseOver"> This should cause some problems on hover </div>

    @code {    
        [Parameter]
        public EventCallback<TestEvent> OnTestEvent {get; set; }
        private async Task HandleMouseOver()
        {
            var testEvent = new TestEvent();
            await OnTestEvent.InvokeAsync(testEvent);
        }
    }
    ```

  - **TestEvent**:
    ```csharp name=TestEvent.cs
    public class TestEvent : EventArgs
    {
        public RenderFragment Fragment {get; init;} = builder => { builder.AddMarkupContent(0, "<div>Test</div>"); };
        public Action SystemAction {get; init; } = () => { };
        public Circular CircularObject {get; init; } = new();
    }

    public class Circular
    {
        public Circular SelfReference { get; set; }

        public Circular()
        {
            SelfReference = this;
        }
    }
    ```

  - **Story**:
    ```csharp name=SerializeComponentStory.razor
    <Story TComponent="SerializeComponent" Name="Default">
        <Template>
            <SerializeComponent @attributes="context.Args" />
        </Template>
    </Story>
    ```
