### PR TITLE
Fix action serialization exceptions on indexers 

### DIFF
--- a/BlazingStory/Internals/Utils/JsonFallbackConverter.cs
+++ b/BlazingStory/Internals/Utils/JsonFallbackConverter.cs
@@ -43,7 +43,9 @@ public class JsonFallbackConverter<[DynamicallyAccessedMembers(PublicProperties)
 
         writer.WriteStartObject();
 
-        var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var properties = typeof(T)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0);
 
         foreach (var property in properties)
         {


### PR DESCRIPTION
Noticed a issue on the github sample page where you get an error in the button story when you click the button: 
https://jsakamoto.github.io/BlazingStory/?path=/docs/components-button--docs

I get this exception: 
```
crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: Arg_GetMethNotFnd
System.ArgumentException: Arg_GetMethNotFnd
   at System.Reflection.RuntimePropertyInfo.GetValue(Object , Object[] )
   at System.Reflection.PropertyInfo.GetValue(Object )
   at BlazingStory.Internals.Utils.JsonFallbackConverter`
 ```
I was unable to reproduce it locally? But I think found the problem where it would throw for indexers, not the exact exception above but that could be a web assembly thing. 

This PR fixes an issue where indexer properties triggered an `System.Reflection.TargetParameterCountException : Parameter count mismatch.` exception during JSON serialization. The fix ensures that any properties exposing index parameters are ignored, preventing invalid calls to property getters.

### Changes
- Updated the serializer logic to skip indexer properties by checking `p.GetIndexParameters().Length == 0`.
- Added a new test to [JsonFallbackSerializerTest.cs](https://github.com/jsakamoto/BlazingStory/compare/main...Snellingen:fix/arg_GetMethNotFnd?expand=1#diff-7f107d10748b4e1992b98512cf036e5d3ea14d7365759914f06c58fd7adfe39f) to confirm that indexers are excluded.

### Testing
▪ Added a class with an indexer that is expected to be skipped during serialization.
▪ Verified in automated tests that serialization avoids the indexer and only includes valid properties.