### PR TITLE
Fix missing XML docs for inherited Blazor components

### DIFF
--- a/ProjectTemplate/Content/BlazingStoryServer/StoryServerApp.csproj
+++ b/ProjectTemplate/Content/BlazingStoryServer/StoryServerApp.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <CopyDocumentationFilesFromPackages>true</CopyDocumentationFilesFromPackages>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR resolves the issue described in #61, where BlazingStory encounters errors when rendering stories for components inheriting from `Microsoft.AspNetCore.Components.Forms.InputBase` due to missing XML documentation files.

### Changes
- Enabled the `CopyDocumentationFilesFromPackages` MSBuild flag in the Server `.csproj` template, ensuring XML documentation from all referenced packages is copied to the output folder.

### Note
I haven't encountered the issue within WebAssembly projects, so I intentionally did **not** apply this flag to the WebAssembly template.