### PR TITLE
feat: searchable filter for Select with many options

### DIFF
--- a/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor
+++ b/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor
@@ -47,10 +47,23 @@
                             </div>
 
                             <div class="parameter-type-holder">
-                                @foreach (var typeString in parameter.GetParameterTypeStrings())
+                                @{
+                                    var typeStrings = parameter.GetParameterTypeStrings().ToArray();
+                                    var maxVisible = 10;
+                                    var visibleStrings = typeStrings.Length > maxVisible
+                                        ? typeStrings.Take(maxVisible)
+                                        : typeStrings;
+                                }
+                                @foreach (var typeString in visibleStrings)
                                 {
                                     <span class="parameter-type">
                                         @typeString
+                                    </span>
+                                }
+                                @if (typeStrings.Length > maxVisible)
+                                {
+                                    <span class="parameter-type parameter-type-overflow">
+                                        ... and @(typeStrings.Length - maxVisible) more
                                     </span>
                                 }
                             </div>

--- a/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor.scss
+++ b/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor.scss
@@ -73,6 +73,10 @@
                         border-radius: 3px;
                         border: 1px solid var(--bs-dimmed-back-color);
                     }
+
+                    & > .parameter-type-overflow {
+                        font-style: italic;
+                    }
                 }
             }
 

--- a/BlazingStory.ToolKit/Inputs/Select.razor
+++ b/BlazingStory.ToolKit/Inputs/Select.razor
@@ -12,7 +12,7 @@
         @if (_IsDropdownOpen)
         {
             <div class="searchable-select-dropdown">
-                @{ var filteredOptions = _FilteredOptions.ToArray(); }
+                @{ var filteredOptions = string.IsNullOrEmpty(_FilterText) ? _Options : _FilteredOptions.ToArray(); }
                 @if (filteredOptions.Any())
                 {
                     @foreach (var option in filteredOptions)
@@ -117,14 +117,15 @@ else
     private async Task _SelectOption((bool Selected, string? Text) option)
     {
         _IsDropdownOpen = false;
-        _FilterText = "";
+        _FilterText = option.Text ?? "";
         await OnChange.InvokeAsync(new ChangeEventArgs { Value = option.Text });
     }
 
     private void _OnFocusOut(FocusEventArgs args)
     {
         _IsDropdownOpen = false;
-        _FilterText = "";
+        var selectedText = _Options.FirstOrDefault(x => x.Selected).Text;
+        _FilterText = selectedText ?? "";
     }
 
     private async Task _OnKeyDown(KeyboardEventArgs args)

--- a/BlazingStory.ToolKit/Inputs/Select.razor
+++ b/BlazingStory.ToolKit/Inputs/Select.razor
@@ -1,22 +1,60 @@
-<span class="select bs-basic-inputs-holder">
-    <SvgIcon Type="SvgIconType.Chevron" />
-
-    @*
-    The `@key` directive is used to force the re-rendering of the select element when the `_NoSelected` field changes.
-    This is necessary because once any available options are selected, adding the `selected` attribute to the disabled 
-    option element for the purpose of restoring the initial state never affects the select element.
-    *@
-    <select @key="_NoSelected" class="bs-basic-inputs" @onchange="this.OnChange">
-        <option disabled selected="@this._NoSelected">Choose option...</option>
-        @foreach (var option in this._Options)
+@if (_IsSearchable)
+{
+    <div class="searchable-select bs-basic-inputs-holder" @onfocusout="_OnFocusOut">
+        <input class="bs-basic-inputs searchable-select-input"
+               type="text"
+               value="@_FilterText"
+               placeholder="@_InputPlaceholder"
+               @oninput="_OnFilterInput"
+               @onfocus="_OnInputFocus"
+               @onkeydown="_OnKeyDown"
+               autocomplete="off" />
+        @if (_IsDropdownOpen)
         {
-            <option selected="@option.Selected">@option.Text</option>
+            <div class="searchable-select-dropdown">
+                @if (_FilteredOptions.Any())
+                {
+                    @foreach (var option in _FilteredOptions)
+                    {
+                        var capturedOption = option;
+                        <div class="searchable-select-option @(option.Selected ? "selected" : "")"
+                             @onmousedown="() => _SelectOption(capturedOption)">
+                            @option.Text
+                        </div>
+                    }
+                }
+                else
+                {
+                    <div class="searchable-select-no-results">No matches</div>
+                }
+            </div>
         }
-    </select>
-</span>
+    </div>
+}
+else
+{
+    <span class="select bs-basic-inputs-holder">
+        <SvgIcon Type="SvgIconType.Chevron" />
+
+        @*
+        The `@key` directive is used to force the re-rendering of the select element when the `_NoSelected` field changes.
+        This is necessary because once any available options are selected, adding the `selected` attribute to the disabled 
+        option element for the purpose of restoring the initial state never affects the select element.
+        *@
+        <select @key="_NoSelected" class="bs-basic-inputs" @onchange="this.OnChange">
+            <option disabled selected="@this._NoSelected">Choose option...</option>
+            @foreach (var option in this._Options)
+            {
+                <option selected="@option.Selected">@option.Text</option>
+            }
+        </select>
+    </span>
+}
 
 @code
 {
+    private const int SearchableThreshold = 20;
+
     /// <summary>
     /// The currently selected value.
     /// </summary>
@@ -39,6 +77,19 @@
 
     private bool _NoSelected = false;
 
+    private bool _IsSearchable => (_Options.Count()) > SearchableThreshold;
+
+    private string _FilterText = "";
+
+    private bool _IsDropdownOpen = false;
+
+    private string? _InputPlaceholder => _Options.FirstOrDefault(x => x.Selected).Text ?? "Choose option...";
+
+    private IEnumerable<(bool Selected, string? Text)> _FilteredOptions =>
+        string.IsNullOrEmpty(_FilterText)
+            ? _Options
+            : _Options.Where(x => x.Text?.Contains(_FilterText, StringComparison.OrdinalIgnoreCase) == true);
+
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
@@ -48,5 +99,49 @@
             .ToArray();
 
         this._NoSelected = !this._Options.Any(item => item.Selected);
+    }
+
+    private void _OnInputFocus()
+    {
+        _FilterText = "";
+        _IsDropdownOpen = true;
+    }
+
+    private void _OnFilterInput(ChangeEventArgs args)
+    {
+        _FilterText = args.Value?.ToString() ?? "";
+        _IsDropdownOpen = true;
+    }
+
+    private async Task _SelectOption((bool Selected, string? Text) option)
+    {
+        _IsDropdownOpen = false;
+        _FilterText = "";
+        await OnChange.InvokeAsync(new ChangeEventArgs { Value = option.Text });
+    }
+
+    private void _OnFocusOut(FocusEventArgs args)
+    {
+        _IsDropdownOpen = false;
+        _FilterText = "";
+    }
+
+    private async Task _OnKeyDown(KeyboardEventArgs args)
+    {
+        if (args.Key == "Escape")
+        {
+            _IsDropdownOpen = false;
+            _FilterText = "";
+            return;
+        }
+
+        if (args.Key == "Enter")
+        {
+            var matches = _FilteredOptions.ToArray();
+            if (matches.Length == 1)
+            {
+                await _SelectOption(matches.First());
+            }
+        }
     }
 }

--- a/BlazingStory.ToolKit/Inputs/Select.razor
+++ b/BlazingStory.ToolKit/Inputs/Select.razor
@@ -12,9 +12,10 @@
         @if (_IsDropdownOpen)
         {
             <div class="searchable-select-dropdown">
-                @if (_FilteredOptions.Any())
+                @{ var filteredOptions = _FilteredOptions.ToArray(); }
+                @if (filteredOptions.Any())
                 {
-                    @foreach (var option in _FilteredOptions)
+                    @foreach (var option in filteredOptions)
                     {
                         var capturedOption = option;
                         <div class="searchable-select-option @(option.Selected ? "selected" : "")"
@@ -73,11 +74,11 @@ else
     [Parameter]
     public EventCallback<ChangeEventArgs> OnChange { get; set; }
 
-    private IEnumerable<(bool Selected, string? Text)> _Options = Enumerable.Empty<(bool, string?)>();
+    private (bool Selected, string? Text)[] _Options = [];
 
     private bool _NoSelected = false;
 
-    private bool _IsSearchable => (_Options.Count()) > SearchableThreshold;
+    private bool _IsSearchable => _Options.Count() > SearchableThreshold;
 
     private string _FilterText = "";
 

--- a/BlazingStory.ToolKit/Inputs/Select.razor.scss
+++ b/BlazingStory.ToolKit/Inputs/Select.razor.scss
@@ -29,8 +29,8 @@
         z-index: 100;
         max-height: 240px;
         overflow-y: auto;
-        background: var(--bs-panel-bg, #fff);
-        border: 1px solid var(--bs-border-color, #ccc);
+        background: var(--bs-inputs-background);
+        border: 1px solid var(--bs-border-color);
         border-radius: 4px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
         margin-top: 2px;
@@ -44,19 +44,19 @@
             text-overflow: ellipsis;
 
             &:hover {
-                background: var(--bs-hover-bg, #f0f0f0);
+                background: var(--bs-hover-back-color);
             }
 
             &.selected {
                 font-weight: 600;
-                background: var(--bs-selected-bg, #e8f0fe);
+                background: var(--bs-hover-light-back-color);
             }
         }
 
         .searchable-select-no-results {
             padding: 8px 12px;
             font-size: 13px;
-            color: var(--bs-muted-color, #888);
+            color: var(--bs-dimmed-text-color);
             font-style: italic;
         }
     }

--- a/BlazingStory.ToolKit/Inputs/Select.razor.scss
+++ b/BlazingStory.ToolKit/Inputs/Select.razor.scss
@@ -10,3 +10,54 @@
     fill: currentColor;
     pointer-events: none;
 }
+
+.searchable-select {
+    position: relative;
+    display: inline-flex;
+    width: 100%;
+
+    .searchable-select-input {
+        width: 100%;
+        cursor: text;
+    }
+
+    .searchable-select-dropdown {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        z-index: 100;
+        max-height: 240px;
+        overflow-y: auto;
+        background: var(--bs-panel-bg, #fff);
+        border: 1px solid var(--bs-border-color, #ccc);
+        border-radius: 4px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        margin-top: 2px;
+
+        .searchable-select-option {
+            padding: 6px 12px;
+            cursor: pointer;
+            font-size: 13px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+
+            &:hover {
+                background: var(--bs-hover-bg, #f0f0f0);
+            }
+
+            &.selected {
+                font-weight: 600;
+                background: var(--bs-selected-bg, #e8f0fe);
+            }
+        }
+
+        .searchable-select-no-results {
+            padding: 8px 12px;
+            font-size: 13px;
+            color: var(--bs-muted-color, #888);
+            font-style: italic;
+        }
+    }
+}

--- a/Tests/BlazingStory.Test/Internals/Components/StoriesRazorDetectorTest.cs
+++ b/Tests/BlazingStory.Test/Internals/Components/StoriesRazorDetectorTest.cs
@@ -43,6 +43,6 @@ internal class StoriesRazorDetectorTest
             .Add(_ => _.StoriesStore, storiesStore));
 
         // Then
-        storiesStore.StoryContainers.Count().Is(7);
+        storiesStore.StoryContainers.Count().Is(8);
     }
 }

--- a/Tests/BlazingStory.Test/Internals/Services/StoryContainerTypesDetectorTest.cs
+++ b/Tests/BlazingStory.Test/Internals/Services/StoryContainerTypesDetectorTest.cs
@@ -24,6 +24,7 @@ internal class StoriesRazorDetectorTest
             .Select(c => $"{c.StoriesAttribute.Title},{c.TypeOfStoriesRazor.FullName}")
             .Is("Examples/UI/Button,BlazingStoryApp1.Stories.Button_stories",
                 "Examples/UI/DumpParameter,BlazingStoryApp1.Stories.DumpParameter_stories",
+                "Examples/LargeEnumSelect,BlazingStoryApp1.Stories.LargeEnumSelect_stories",
                 "Lorem/Ipsum/Header,BlazingStoryApp1.Stories.LoremIpsum_stories",
                 "Examples/UI/Rating,BlazingStoryApp1.Stories.Rating_stories",
                 "Examples/Select,BlazingStoryApp1.Stories.Select_stories",

--- a/Tests/Fixtures/BlazingStoryApp1/Stories/LargeEnumSelect.stories.razor
+++ b/Tests/Fixtures/BlazingStoryApp1/Stories/LargeEnumSelect.stories.razor
@@ -1,0 +1,9 @@
+@attribute [Stories("Examples/LargeEnumSelect")]
+
+<Stories TComponent="LargeEnumComponent">
+    <Story Name="Default">
+        <Template>
+            <LargeEnumComponent @attributes="context.Args" />
+        </Template>
+    </Story>
+</Stories>

--- a/Tests/Fixtures/BlazingStoryApp1/Stories/LargeEnumSelect.stories.razor
+++ b/Tests/Fixtures/BlazingStoryApp1/Stories/LargeEnumSelect.stories.razor
@@ -1,6 +1,7 @@
 @attribute [Stories("Examples/LargeEnumSelect")]
 
 <Stories TComponent="LargeEnumComponent">
+    <ArgType For="_ => _.Value" Control="ControlType.Select" />
     <Story Name="Default">
         <Template>
             <LargeEnumComponent @attributes="context.Args" />

--- a/Tests/Fixtures/RazorClassLib1/Components/DumpParameter/LargeEnum.cs
+++ b/Tests/Fixtures/RazorClassLib1/Components/DumpParameter/LargeEnum.cs
@@ -1,0 +1,9 @@
+namespace RazorClassLib1.Components.DumpParameter;
+
+public enum LargeEnum
+{
+    Alpha, Beta, Gamma, Delta, Epsilon, Zeta, Eta, Theta, Iota, Kappa,
+    Lambda, Mu, Nu, Xi, Omicron, Pi, Rho, Sigma, Tau, Upsilon,
+    Phi, Chi, Psi, Omega,
+    Red, Orange, Yellow, Green, Blue, Indigo, Violet
+}

--- a/Tests/Fixtures/RazorClassLib1/Components/DumpParameter/LargeEnumComponent.razor
+++ b/Tests/Fixtures/RazorClassLib1/Components/DumpParameter/LargeEnumComponent.razor
@@ -1,0 +1,5 @@
+<div>Selected: @Value</div>
+
+@code {
+    [Parameter] public LargeEnum Value { get; set; }
+}


### PR DESCRIPTION
## Summary

When the `Select` component receives more than 20 items, it renders a searchable text input with a filtered dropdown instead of a plain HTML `<select>` element. This makes large enums (e.g., 5000+ icon values) usable in the Controls panel.

- Below the threshold (≤ 20 items), existing `<select>` behavior is preserved exactly
- Uses existing BlazingStory CSS variables (`--bs-inputs-background`, `--bs-hover-back-color`, etc.) for consistent light/dark theme support
- Keyboard support: `Enter` selects single match, `Escape` closes dropdown

## Motivation

Enums with thousands of values (e.g., icon libraries like Tabler Icons with 5000+ entries) render an unusable native `<select>` dropdown in the Controls panel. This change adds a type-to-filter input that narrows the options list as the user types.

## Changes

- `BlazingStory.ToolKit/Inputs/Select.razor` - Dual-mode rendering: standard `<select>` for small lists, searchable combobox for large lists
- `BlazingStory.ToolKit/Inputs/Select.razor.scss` - Dropdown styling using existing design tokens
- Test fixtures: `LargeEnum` (31 values), `LargeEnumComponent`, and story to exercise the searchable mode

## Test plan

- [ ] Existing tests pass (6 pre-existing `Detect_Test` failures unrelated to this change)
- [ ] Small enums (≤ 20 values) still render as plain `<select>`
- [ ] Large enums (> 20 values) render searchable input with dropdown
- [ ] Typing filters the dropdown list (case-insensitive)
- [ ] Clicking an option selects it and fires OnChange
- [ ] Pressing Enter with one match selects it
- [ ] Pressing Escape closes the dropdown
- [ ] Works in both light and dark themes