### PR TITLE
Exclude iframe.html from static web asset pre-compression (#88)

### DIFF
--- a/BlazingStory/Build/BlazingStory.targets
+++ b/BlazingStory/Build/BlazingStory.targets
@@ -2,6 +2,22 @@
   <Import Project="$(MSBuildThisFileDirectory)CustomTasks\_BS_ResolveAdditionalReferenceDocsTask.targets" />
 
   <!--
+  Exclude iframe.html from static web asset pre-compression.
+  .NET 10's MapStaticAssets pre-compresses HTML files (gzip), but Visual Studio's dev server
+  applies additional compression on top of the already-compressed response, causing
+  ERR_CONTENT_DECODING_FAILED in the browser. Excluding iframe.html ensures MapStaticAssets
+  always serves the plain file, allowing VS to compress it correctly once.
+  See: https://github.com/jsakamoto/BlazingStory/issues/88
+  -->
+  <Target Name="_BS_ExcludeIframeHtmlFromCompression" BeforeTargets="ResolveBuildCompressedStaticWebAssetsConfiguration;ResolvePublishCompressedStaticWebAssetsConfiguration">
+    <PropertyGroup>
+      <CompressionExcludePatterns>$(CompressionExcludePatterns);**/iframe.html</CompressionExcludePatterns>
+    </PropertyGroup>
+  </Target>
+
+
+
+  <!--
   This target is used to generate the BlazingStoryAssemblyInfo.cs file wihch contains project meta data such as project directory, root namespace.
   This is required to the "Show Code" feature in the "Docs" pages.
   -->


### PR DESCRIPTION
## Problem

When running BlazingStory through Visual Studio's debugger on .NET 10, `iframe.html` responses fail with `ERR_CONTENT_DECODING_FAILED (200 OK)`, leaving the component canvas blank.

**Root cause:** .NET 10's `MapStaticAssets` pre-compresses `**/*.html` files (gzip), registering both compressed and uncompressed variants in `staticwebassets.endpoints.json`. VS dev server then applies additional compression on top of the already-compressed response, causing double-compression the browser can't decode.

`index.html` is unaffected because it's served via `MapFallbackToFile` (SPA fallback), which bypasses `MapStaticAssets` compression.

This does NOT occur with `dotnet run` or `dotnet watch` - only the VS debugger.

Fixes #88

## Fix

Added an MSBuild target in `BlazingStory.targets` that excludes `iframe.html` from the `CompressionExcludePatterns` property. This prevents .NET 10 from creating pre-compressed variants, so `MapStaticAssets` always serves the plain file. VS can then compress it correctly (once).

The target uses `BeforeTargets="ResolveBuildCompressedStaticWebAssetsConfiguration;ResolvePublishCompressedStaticWebAssetsConfiguration"` to ensure the property is set after the SDK defines it but before the compression task runs.

## Test plan

- [x] Run through Visual Studio debugger on .NET 10 - verify components render in canvas
- [x] Run via `dotnet run` / `dotnet watch` - verify no regression
- [x] Verify `staticwebassets.endpoints.json` has no gzip variant for `iframe.html` after build
- [x] Test on .NET 8 and .NET 9 - verify no regression (compression pipeline differs)
