### PR TITLE
Add MCP tools for custom pages

### DIFF
--- a/BlazingStory.McpServer/CustomPagesTool.cs
+++ b/BlazingStory.McpServer/CustomPagesTool.cs
@@ -1,0 +1,153 @@
+using System.ComponentModel;
+using BlazingStory.Components;
+using BlazingStory.Internals.Models;
+using BlazingStory.Internals.Services;
+using BlazingStory.McpServer.Internals;
+using BlazingStory.McpServer.ResultTypes;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+
+namespace BlazingStory.McpServer;
+
+[McpServerToolType]
+internal class CustomPagesTool
+{
+    private readonly IServiceProvider _services;
+
+    private readonly CustomPageContentCache _cache;
+
+    public CustomPagesTool(IServiceProvider services, CustomPageContentCache cache)
+    {
+        this._services = services;
+        this._cache = cache;
+    }
+
+    [McpServerTool(Name = "getCustomPages", UseStructuredContent = true)]
+    [Description("""
+        Retrieves a list of all custom pages and markdown pages available in this UI catalog.
+        Custom pages typically contain general information such as getting started guides, setup instructions, or documentation that is not tied to a specific component.
+        For each page, it returns the title.
+        To retrieve the full content of a specific page, use the `getCustomPageContent` tool, or use `searchCustomPages` to search across all pages by keyword.
+        """)]
+    public async Task<CustomPageSummariesResult> GetCustomPagesAsync()
+    {
+        using var scope = this._services.CreateScope();
+        var customPageStore = await this.BuildCustomPageStoreAsync(scope);
+
+        var pages = customPageStore.CustomPageContainers.Select(c => new CustomPageSummary(
+            Title: c.Title
+        )).ToList();
+
+        return new(pages);
+    }
+
+    [McpServerTool(Name = "getCustomPageContent", UseStructuredContent = true)]
+    [Description("""
+        Retrieves the full rendered HTML content of a specific custom page or markdown page, identified by its title.
+        The result includes the page title and the complete rendered HTML content.
+        Use this tool after calling `getCustomPages` to get the list of available pages and their titles.
+        """)]
+    public async Task<CustomPageDetail> GetCustomPageContentAsync(
+        [Description("The title of the custom page to retrieve content for (e.g., \"Getting Started\").")]
+        string pageTitle)
+    {
+        using var scope = this._services.CreateScope();
+        var customPageStore = await this.BuildCustomPageStoreAsync(scope);
+
+        var container = customPageStore.CustomPageContainers.FirstOrDefault(c =>
+            c.Title.Equals(pageTitle, StringComparison.OrdinalIgnoreCase));
+        if (container is null) throw new McpException($"Custom page '{pageTitle}' not found.");
+
+        return await this.GetOrRenderPageAsync(container, scope);
+    }
+
+    [McpServerTool(Name = "searchCustomPages", UseStructuredContent = true)]
+    [Description("""
+        Searches across all custom pages and markdown pages for content matching the given query.
+        Returns matching pages ordered by relevance, each with a contextual text snippet around the matched terms.
+        Use this tool to find relevant documentation, setup instructions, or guides without needing to know the exact page title.
+        To retrieve the full content of a matching page, use the `getCustomPageContent` tool with the page title from the results.
+        """)]
+    public async Task<CustomPageSearchResult> SearchCustomPagesAsync(
+        [Description("The search query to match against custom page content (e.g., \"getting started\", \"setup instructions\").")]
+        string query)
+    {
+        using var scope = this._services.CreateScope();
+        var customPageStore = await this.BuildCustomPageStoreAsync(scope);
+
+        await this.EnsureCachePopulatedAsync(customPageStore, scope);
+
+        var entries = this._cache.GetAllEntries().ToArray();
+        var entriesByPath = entries.ToDictionary(e => e.NavigationPath);
+        var index = this._cache.GetOrBuildIndex();
+        var scored = Bm25Scorer.Search(index, query);
+
+        var results = scored
+            .Where(hit => entriesByPath.ContainsKey(hit.Key))
+            .Select(hit =>
+            {
+                var entry = entriesByPath[hit.Key];
+                var plainText = Bm25Scorer.StripHtmlTags(entry.HtmlContent);
+                var snippet = Bm25Scorer.ExtractSnippet(plainText, query);
+                return new CustomPageSearchHit(entry.Title, snippet);
+            }).ToList();
+
+        return new(results);
+    }
+
+    private async Task<CustomPageDetail> GetOrRenderPageAsync(CustomPageContainer container, IServiceScope scope)
+    {
+        if (this._cache.TryGetEntry(container.NavigationPath, out var cached))
+        {
+            return new CustomPageDetail(cached.Title, cached.HtmlContent);
+        }
+
+        var html = await CustomStaticHtmlRenderer.RenderToHtmlStringAsync(
+            container.CustomPageRazorDescriptor.TypeOfCustomPageRazor,
+            scope.ServiceProvider,
+            ParameterView.Empty);
+
+        html = string.Join('\n', html.Split('\n').Select(line => line.Trim(' ', '\t', '\n')));
+
+        var entry = new CustomPageCacheEntry(container.Title, container.NavigationPath, html);
+        this._cache.SetEntry(container.NavigationPath, entry);
+
+        return new CustomPageDetail(entry.Title, entry.HtmlContent);
+    }
+
+    private async Task EnsureCachePopulatedAsync(CustomPageStore customPageStore, IServiceScope scope)
+    {
+        foreach (var container in customPageStore.CustomPageContainers)
+        {
+            if (!this._cache.TryGetEntry(container.NavigationPath, out _))
+            {
+                await this.GetOrRenderPageAsync(container, scope);
+            }
+        }
+    }
+
+    private async ValueTask<CustomPageStore> BuildCustomPageStoreAsync(IServiceScope scope)
+    {
+        var endpointDataSource = this._services.GetRequiredService<EndpointDataSource>();
+
+        var indexComponentType = endpointDataSource.Endpoints
+            .SelectMany(endpoint => endpoint.Metadata)
+            .OfType<RootComponentMetadata>()
+            .Where(metaData => metaData.Type.IsGenericType && metaData.Type.GetGenericTypeDefinition() == typeof(BlazingStoryServerComponent<,>))
+            .Select(metaData => metaData.Type.GenericTypeArguments.First())
+            .FirstOrDefault();
+
+        var scopedServices = scope.ServiceProvider;
+
+        if (indexComponentType is not null)
+        {
+            await CustomStaticHtmlRenderer.RenderToHtmlStringAsync(indexComponentType, scopedServices, ParameterView.Empty);
+        }
+
+        return scopedServices.GetRequiredService<CustomPageStore>();
+    }
+}

--- a/BlazingStory.McpServer/CustomPagesTool.cs
+++ b/BlazingStory.McpServer/CustomPagesTool.cs
@@ -87,11 +87,11 @@ internal class CustomPagesTool
         var scored = Bm25Scorer.Search(index, query);
 
         var results = scored
-            .Where(hit => entriesByPath.ContainsKey(hit.Key))
-            .Select(hit =>
+            .Select(hit => entriesByPath.TryGetValue(hit.Key, out var entry) ? entry : null)
+            .Where(entry => entry is not null)
+            .Select(entry =>
             {
-                var entry = entriesByPath[hit.Key];
-                var plainText = Bm25Scorer.StripHtmlTags(entry.HtmlContent);
+                var plainText = Bm25Scorer.StripHtmlTags(entry!.HtmlContent);
                 var snippet = Bm25Scorer.ExtractSnippet(plainText, query);
                 return new CustomPageSearchHit(entry.Title, snippet);
             }).ToList();

--- a/BlazingStory.McpServer/Internals/Bm25Scorer.cs
+++ b/BlazingStory.McpServer/Internals/Bm25Scorer.cs
@@ -1,0 +1,204 @@
+using System.Text.RegularExpressions;
+
+namespace BlazingStory.McpServer.Internals;
+
+/// <summary>
+/// Provides BM25 Okapi ranking for full-text search over custom page content.
+/// </summary>
+internal static partial class Bm25Scorer
+{
+    private const double K1 = 1.5;
+    private const double B = 0.75;
+
+    /// <summary>
+    /// Scores documents in the index against the given query, returning results ordered by relevance.
+    /// </summary>
+    /// <param name="index">The precomputed BM25 index containing documents and their term frequencies.</param>
+    /// <param name="query">The search query string.</param>
+    /// <returns>A list of results with positive scores, sorted by descending relevance.</returns>
+    public static IReadOnlyList<Bm25Result> Search(Bm25Index index, string query)
+    {
+        var docs = index.Documents;
+        if (docs.Length == 0) return [];
+
+        var queryTerms = Tokenize(query);
+        if (queryTerms.Length == 0) return [];
+
+        var avgDocLength = index.AvgDocLength;
+        var totalDocs = docs.Length;
+
+        var results = new List<Bm25Result>();
+        foreach (var doc in docs)
+        {
+            var score = 0.0;
+            foreach (var term in queryTerms)
+            {
+                var df = index.DocumentFrequencies.GetValueOrDefault(term, 0);
+                var idf = Math.Log((totalDocs - df + 0.5) / (df + 0.5) + 1.0);
+
+                var tf = doc.TermFrequencies.GetValueOrDefault(term, 0);
+                var numerator = tf * (K1 + 1.0);
+                var denominator = tf + K1 * (1.0 - B + B * doc.TokenCount / avgDocLength);
+
+                score += idf * numerator / denominator;
+            }
+
+            if (score > 0)
+            {
+                results.Add(new Bm25Result(doc.Key, score));
+            }
+        }
+
+        results.Sort((a, b) => b.Score.CompareTo(a.Score));
+        return results;
+    }
+
+    /// <summary>
+    /// Creates a BM25 document from raw text by tokenizing and computing term frequencies.
+    /// </summary>
+    /// <param name="key">A unique key identifying the document.</param>
+    /// <param name="text">The plain text content to index.</param>
+    /// <returns>A <see cref="Bm25Document"/> ready for inclusion in a <see cref="Bm25Index"/>.</returns>
+    public static Bm25Document CreateDocument(string key, string text)
+    {
+        var tokens = Tokenize(text);
+        var termFrequencies = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var token in tokens)
+        {
+            termFrequencies[token] = termFrequencies.GetValueOrDefault(token, 0) + 1;
+        }
+        return new Bm25Document(key, tokens.Length, termFrequencies);
+    }
+
+    /// <summary>
+    /// Strips HTML tags and comments from the given HTML string, returning plain text.
+    /// </summary>
+    /// <param name="html">The HTML content to strip.</param>
+    /// <returns>The plain text with HTML tags and comments replaced by spaces.</returns>
+    public static string StripHtmlTags(string html)
+    {
+        var withoutComments = HtmlCommentRegex().Replace(html, " ");
+        return HtmlTagRegex().Replace(withoutComments, " ");
+    }
+
+    /// <summary>
+    /// Extracts a text snippet centered around the first occurrence of a query term in the given plain text.
+    /// </summary>
+    /// <param name="plainText">The plain text to extract a snippet from.</param>
+    /// <param name="query">The search query used to locate the snippet center.</param>
+    /// <param name="contextChars">The number of characters to include before and after the match.</param>
+    /// <returns>A snippet string, prefixed/suffixed with "..." if truncated.</returns>
+    public static string ExtractSnippet(string plainText, string query, int contextChars = 200)
+    {
+        var queryTerms = Tokenize(query);
+        if (queryTerms.Length == 0) return Truncate(plainText, contextChars * 2);
+
+        var bestIndex = -1;
+        foreach (var term in queryTerms)
+        {
+            var index = plainText.IndexOf(term, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0 && (bestIndex < 0 || index < bestIndex))
+            {
+                bestIndex = index;
+            }
+        }
+
+        if (bestIndex < 0) return Truncate(plainText, contextChars * 2);
+
+        var start = Math.Max(0, bestIndex - contextChars);
+        var end = Math.Min(plainText.Length, bestIndex + contextChars);
+
+        var snippet = plainText[start..end];
+        if (start > 0) snippet = "..." + snippet;
+        if (end < plainText.Length) snippet += "...";
+
+        return CollapseWhitespace(snippet);
+    }
+
+    private static string Truncate(string text, int maxLength)
+    {
+        var collapsed = CollapseWhitespace(text);
+        if (collapsed.Length <= maxLength) return collapsed;
+        return collapsed[..maxLength] + "...";
+    }
+
+    private static string CollapseWhitespace(string text)
+    {
+        return WhitespaceRegex().Replace(text, " ").Trim();
+    }
+
+    private static string[] Tokenize(string text)
+    {
+        return TokenRegex().Matches(text)
+            .Select(m => m.Value.ToLowerInvariant())
+            .Where(t => t.Length >= 2)
+            .ToArray();
+    }
+
+    [GeneratedRegex(@"<!--.*?-->", RegexOptions.Singleline)]
+    private static partial Regex HtmlCommentRegex();
+
+    [GeneratedRegex(@"<[^>]+>")]
+    private static partial Regex HtmlTagRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex(@"\w+")]
+    private static partial Regex TokenRegex();
+}
+
+/// <summary>
+/// Represents a tokenized document with precomputed term frequencies for BM25 scoring.
+/// </summary>
+/// <param name="Key">A unique key identifying the document.</param>
+/// <param name="TokenCount">The total number of tokens in the document.</param>
+/// <param name="TermFrequencies">A dictionary mapping each token to its occurrence count.</param>
+internal record Bm25Document(string Key, int TokenCount, Dictionary<string, int> TermFrequencies);
+
+/// <summary>
+/// Represents a BM25 search result with a document key and relevance score.
+/// </summary>
+/// <param name="Key">The key of the matched document.</param>
+/// <param name="Score">The BM25 relevance score (higher is more relevant).</param>
+internal record Bm25Result(string Key, double Score);
+
+/// <summary>
+/// A precomputed BM25 index containing documents, average document length, and document frequencies.
+/// </summary>
+internal class Bm25Index
+{
+    /// <summary>
+    /// Gets the indexed documents.
+    /// </summary>
+    public Bm25Document[] Documents { get; }
+
+    /// <summary>
+    /// Gets the average document length across all documents.
+    /// </summary>
+    public double AvgDocLength { get; }
+
+    /// <summary>
+    /// Gets the document frequency for each term (number of documents containing the term).
+    /// </summary>
+    public Dictionary<string, int> DocumentFrequencies { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Bm25Index"/> class, precomputing document frequencies and average length.
+    /// </summary>
+    /// <param name="documents">The documents to index.</param>
+    public Bm25Index(Bm25Document[] documents)
+    {
+        this.Documents = documents;
+        this.AvgDocLength = documents.Length > 0 ? Math.Max(1.0, documents.Average(d => d.TokenCount)) : 1.0;
+
+        this.DocumentFrequencies = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var doc in documents)
+        {
+            foreach (var term in doc.TermFrequencies.Keys)
+            {
+                this.DocumentFrequencies[term] = this.DocumentFrequencies.GetValueOrDefault(term, 0) + 1;
+            }
+        }
+    }
+}

--- a/BlazingStory.McpServer/Internals/CustomPageContentCache.cs
+++ b/BlazingStory.McpServer/Internals/CustomPageContentCache.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace BlazingStory.McpServer.Internals;
+
+/// <summary>
+/// A singleton cache that stores rendered HTML content of custom pages and maintains a lazy BM25 search index.
+/// </summary>
+internal class CustomPageContentCache
+{
+    private readonly ConcurrentDictionary<string, CustomPageCacheEntry> _cache = new();
+
+    private readonly object _indexLock = new();
+
+    private Bm25Index? _bm25Index;
+
+    /// <summary>
+    /// Tries to retrieve a cached entry by its navigation path.
+    /// </summary>
+    /// <param name="navigationPath">The navigation path to look up.</param>
+    /// <param name="entry">The cached entry, if found.</param>
+    /// <returns><c>true</c> if the entry was found; otherwise, <c>false</c>.</returns>
+    public bool TryGetEntry(string navigationPath, [NotNullWhen(true)] out CustomPageCacheEntry? entry)
+        => this._cache.TryGetValue(navigationPath, out entry);
+
+    /// <summary>
+    /// Stores a rendered page entry in the cache and invalidates the BM25 index.
+    /// </summary>
+    /// <param name="navigationPath">The navigation path used as the cache key.</param>
+    /// <param name="entry">The entry containing the rendered page content.</param>
+    public void SetEntry(string navigationPath, CustomPageCacheEntry entry)
+    {
+        this._cache[navigationPath] = entry;
+        lock (this._indexLock) { this._bm25Index = null; }
+    }
+
+    /// <summary>
+    /// Returns all cached entries.
+    /// </summary>
+    /// <returns>An enumerable of all cached page entries.</returns>
+    public IEnumerable<CustomPageCacheEntry> GetAllEntries()
+        => this._cache.Values;
+
+    /// <summary>
+    /// Returns the BM25 index, building it from cached entries on first access or after invalidation.
+    /// </summary>
+    /// <returns>A precomputed <see cref="Bm25Index"/> over all cached page content.</returns>
+    public Bm25Index GetOrBuildIndex()
+    {
+        lock (this._indexLock)
+        {
+            if (this._bm25Index is not null) return this._bm25Index;
+
+            var documents = this._cache.Values.Select(entry =>
+            {
+                var plainText = Bm25Scorer.StripHtmlTags(entry.HtmlContent);
+                var searchableText = entry.Title + " " + plainText;
+                return Bm25Scorer.CreateDocument(entry.NavigationPath, searchableText);
+            }).ToArray();
+
+            this._bm25Index = new Bm25Index(documents);
+            return this._bm25Index;
+        }
+    }
+}
+
+/// <summary>
+/// Represents a cached custom page with its rendered HTML content.
+/// </summary>
+/// <param name="Title">The title of the custom page.</param>
+/// <param name="NavigationPath">The navigation path used as the cache key.</param>
+/// <param name="HtmlContent">The rendered HTML content of the page.</param>
+internal record CustomPageCacheEntry(string Title, string NavigationPath, string HtmlContent);

--- a/BlazingStory.McpServer/McpServerExtensions.cs
+++ b/BlazingStory.McpServer/McpServerExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using BlazingStory.Internals.Services;
+using BlazingStory.McpServer.Internals;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,10 +22,13 @@ public static class McpServerExtensions
     public static IMcpServerBuilder AddBlazingStoryMcpServer(this IServiceCollection services, Action<McpServerOptions>? configureMcpServerOptions = null)
     {
         services.AddScoped((_) => new StoriesStore());
+        services.AddScoped((_) => new CustomPageStore());
+        services.AddSingleton<CustomPageContentCache>();
         return services
             .AddMcpServer(options => configureMcpServerOptions?.Invoke(options))
             .WithHttpTransport(options => { })
-            .WithTools<StoriesTool>();
+            .WithTools<StoriesTool>()
+            .WithTools<CustomPagesTool>();
     }
 
     /// <summary>

--- a/BlazingStory.McpServer/ResultTypes/CustomPageDetail.cs
+++ b/BlazingStory.McpServer/ResultTypes/CustomPageDetail.cs
@@ -1,0 +1,8 @@
+namespace BlazingStory.McpServer.ResultTypes;
+
+/// <summary>
+/// Represents a custom page with its full rendered HTML content.
+/// </summary>
+/// <param name="Title">The title of the custom page.</param>
+/// <param name="HtmlContent">The rendered HTML content of the custom page.</param>
+public record CustomPageDetail(string Title, string HtmlContent);

--- a/BlazingStory.McpServer/ResultTypes/CustomPageSearchHit.cs
+++ b/BlazingStory.McpServer/ResultTypes/CustomPageSearchHit.cs
@@ -1,0 +1,8 @@
+namespace BlazingStory.McpServer.ResultTypes;
+
+/// <summary>
+/// Represents a search result for a custom page, including a content snippet.
+/// </summary>
+/// <param name="Title">The title of the matching custom page.</param>
+/// <param name="Snippet">A text snippet showing content around the matched terms.</param>
+public record CustomPageSearchHit(string Title, string Snippet);

--- a/BlazingStory.McpServer/ResultTypes/CustomPageSearchResult.cs
+++ b/BlazingStory.McpServer/ResultTypes/CustomPageSearchResult.cs
@@ -1,0 +1,21 @@
+namespace BlazingStory.McpServer.ResultTypes;
+
+/// <summary>
+/// Represents the result of searching custom pages.
+/// </summary>
+public class CustomPageSearchResult
+{
+    /// <summary>
+    /// Gets the collection of search hits, ordered by relevance.
+    /// </summary>
+    public IEnumerable<CustomPageSearchHit> Results { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomPageSearchResult"/> class.
+    /// </summary>
+    /// <param name="results">The search hits ordered by relevance.</param>
+    public CustomPageSearchResult(IEnumerable<CustomPageSearchHit> results)
+    {
+        this.Results = results;
+    }
+}

--- a/BlazingStory.McpServer/ResultTypes/CustomPageSummariesResult.cs
+++ b/BlazingStory.McpServer/ResultTypes/CustomPageSummariesResult.cs
@@ -1,0 +1,21 @@
+namespace BlazingStory.McpServer.ResultTypes;
+
+/// <summary>
+/// Represents the result of a custom page summaries query.
+/// </summary>
+public class CustomPageSummariesResult
+{
+    /// <summary>
+    /// Gets the collection of custom page summaries.
+    /// </summary>
+    public IEnumerable<CustomPageSummary> CustomPages { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomPageSummariesResult"/> class with the specified custom page summaries.
+    /// </summary>
+    /// <param name="customPages">The collection of custom page summaries to include in the result.</param>
+    public CustomPageSummariesResult(IEnumerable<CustomPageSummary> customPages)
+    {
+        this.CustomPages = customPages;
+    }
+}

--- a/BlazingStory.McpServer/ResultTypes/CustomPageSummary.cs
+++ b/BlazingStory.McpServer/ResultTypes/CustomPageSummary.cs
@@ -1,0 +1,7 @@
+namespace BlazingStory.McpServer.ResultTypes;
+
+/// <summary>
+/// Represents a summary of a custom page.
+/// </summary>
+/// <param name="Title">The title of the custom page (e.g., "Guides/MCP Integration").</param>
+public record CustomPageSummary(string Title);

--- a/BlazingStory/Components/BlazingStoryApp.razor
+++ b/BlazingStory/Components/BlazingStoryApp.razor
@@ -198,10 +198,13 @@
 
     protected override void OnInitialized()
     {
-        CustomPageRazorDetector.DetectAndRegisterToStore(Assemblies, _CustomPageStore);
-
         var injectedStoriesStore = this.GlobalServices.GetService<StoriesStore>();
         if (injectedStoriesStore is not null) this._StoriesStore = injectedStoriesStore;
+
+        var injectedCustomPageStore = this.GlobalServices.GetService<CustomPageStore>();
+        if (injectedCustomPageStore is not null) this._CustomPageStore = injectedCustomPageStore;
+
+        CustomPageRazorDetector.DetectAndRegisterToStore(Assemblies, _CustomPageStore);
 
         var addonStore = new BlazingStory.Addons.Internals.AddonStore();
         this.ConfigureAddons(addonStore);

--- a/Samples/MCPServer/MyBlazorWasmApp1.Stories/Components/Stories/DesignTokens.md
+++ b/Samples/MCPServer/MyBlazorWasmApp1.Stories/Components/Stories/DesignTokens.md
@@ -1,0 +1,58 @@
+---
+$attribute: CustomPage("Guides/Design Tokens")
+---
+
+## Design Tokens
+
+Design tokens are the shared values that define your design system — colors, spacing, typography, and other visual properties. Using tokens ensures consistency across all components.
+
+### Token categories
+
+#### Colors
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--color-primary` | `#1ea7fd` | Primary actions, links |
+| `--color-secondary` | `#6c757d` | Secondary actions |
+| `--color-success` | `#28a745` | Success states |
+| `--color-danger` | `#dc3545` | Error states, destructive actions |
+| `--color-warning` | `#ffc107` | Warning messages |
+
+#### Spacing
+
+All spacing uses a 4px base unit:
+
+| Token | Value |
+|-------|-------|
+| `--space-xs` | `4px` |
+| `--space-sm` | `8px` |
+| `--space-md` | `16px` |
+| `--space-lg` | `24px` |
+| `--space-xl` | `32px` |
+
+#### Typography
+
+| Token | Value |
+|-------|-------|
+| `--font-family` | `'Nunito Sans', sans-serif` |
+| `--font-size-sm` | `12px` |
+| `--font-size-md` | `14px` |
+| `--font-size-lg` | `16px` |
+| `--font-weight-normal` | `400` |
+| `--font-weight-bold` | `700` |
+
+### Using tokens in components
+
+Apply tokens via CSS custom properties in your component styles:
+
+```css
+.my-button {
+    background-color: var(--color-primary);
+    padding: var(--space-sm) var(--space-md);
+    font-family: var(--font-family);
+    font-size: var(--font-size-md);
+    border-radius: 4px;
+}
+```
+
+This approach makes it easy to update your entire design system by changing token values in one place.

--- a/Samples/MCPServer/MyBlazorWasmApp1.Stories/Components/Stories/GettingStarted.md
+++ b/Samples/MCPServer/MyBlazorWasmApp1.Stories/Components/Stories/GettingStarted.md
@@ -1,0 +1,45 @@
+---
+$attribute: CustomPage("Getting Started")
+---
+
+## Getting Started
+
+This UI catalog is built with **Blazing Story**, a clone of [Storybook](https://storybook.js.org/) for Blazor.
+
+### Quick setup
+
+Install the project template and create a new Blazing Story app:
+
+```shell
+dotnet new install BlazingStory.ProjectTemplates
+dotnet new blazingstorywasm -n MyApp.Stories
+dotnet sln add ./MyApp.Stories/
+dotnet add ./MyApp.Stories reference ./MyApp
+```
+
+### Writing stories
+
+Add a `.stories.razor` file for each component you want to document:
+
+```html
+@using MyApp.Components
+@attribute [Stories("Components/Button")]
+
+<Stories TComponent="Button">
+    <Story Name="Primary">
+        <Template>
+            <Button Label="Click me" Primary="true" @attributes="context.Args" />
+        </Template>
+    </Story>
+</Stories>
+```
+
+### Layouts
+
+You can apply layout components at three levels:
+
+- **Application** — `DefaultLayout` on `BlazingStoryApp`
+- **Component** — `Layout` on `<Stories>`
+- **Story** — `Layout` on `<Story>`
+
+For full documentation visit [blazingstory.github.io/docs](https://blazingstory.github.io/docs/).

--- a/Samples/MCPServer/MyBlazorWasmApp1.Stories/Components/Stories/McpIntegration.md
+++ b/Samples/MCPServer/MyBlazorWasmApp1.Stories/Components/Stories/McpIntegration.md
@@ -1,0 +1,45 @@
+---
+$attribute: CustomPage("Guides/MCP Integration")
+---
+
+## MCP Integration
+
+This Blazing Story app exposes a **Model Context Protocol (MCP)** server, allowing AI assistants and other MCP clients to query the UI catalog programmatically.
+
+### How it works
+
+The MCP server runs alongside the Blazing Story web app. When a client connects, it can discover components, read their parameters and stories, and search documentation pages — all through structured tool calls.
+
+### Available tools
+
+| Tool | Description |
+|------|-------------|
+| `getComponents` | List all components in the catalog with name and summary |
+| `getComponentParameters` | Get the configurable parameters for a component |
+| `getComponentStories` | Get usage examples with code snippets |
+| `getCustomPages` | List all custom and markdown documentation pages |
+| `getCustomPageContent` | Retrieve the full rendered content of a page |
+| `searchCustomPages` | Search across all pages by keyword with relevance ranking |
+
+### Connecting a client
+
+Point your MCP client at the server endpoint:
+
+```
+http://localhost:5277/mcp/blazingstory
+```
+
+The server uses HTTP transport with the Streamable HTTP protocol.
+
+### Setup in your project
+
+Add the MCP server NuGet package and wire it up in `Program.cs`:
+
+```csharp
+builder.Services.AddBlazingStoryMcpServer();
+
+var app = builder.Build();
+app.MapBlazingStoryMcp();
+```
+
+That's it — the MCP endpoint is now available at `/mcp/blazingstory`.


### PR DESCRIPTION
## Summary

Adds MCP tools for querying custom pages and markdown pages, as requested in #115. Closes #115.

## Changes

- Three new MCP tools: `getCustomPages`, `getCustomPageContent`, and `searchCustomPages`
- `searchCustomPages` uses BM25 Okapi ranking with precomputed document frequencies, returning relevance-ordered results with contextual snippets
- Singleton cache for rendered page content with lazy index building
- Inject `CustomPageStore` from DI before detection populates it
- Sample custom pages added to the MCPServer sample app

## Testing

- All 465 existing tests pass
- Manually tested all three tools using MCPJam against the MCPServer sample app:
  - `getCustomPages` returns all 4 registered pages
  - `getCustomPageContent` with title "Getting Started" returns full rendered HTML
  - `searchCustomPages` with "color" ranks Design Tokens highest
  - `searchCustomPages` with "MCP" ranks MCP Integration highest
  - `searchCustomPages` with "stories" matches multiple pages
  - Verified existing tools (`getComponents`, `getComponentParameters`, `getComponentStories`) still work