### PR TITLE
Fix reference-type story args round-tripping to literal "(null)"

### DIFF
--- a/BlazingStory.ToolKit/Utils/TypeUtility.cs
+++ b/BlazingStory.ToolKit/Utils/TypeUtility.cs
@@ -108,7 +108,8 @@ public static class TypeUtility
         var primaryType = targetTypeStructure.PrimaryType;
         var isNullable = targetTypeStructure.IsNullable;
 
-        if (isNullable && sourceString == "(null)")
+        // Both OR branches needed: isNullable covers Nullable<T>, !IsValueType covers reference types.
+        if (sourceString == "(null)" && (isNullable || !primaryType.IsValueType))
         {
             convertedValue = null;
             return true;

--- a/Tests/BlazingStory.Test/Internals/Utils/TypeUtilityTest.cs
+++ b/Tests/BlazingStory.Test/Internals/Utils/TypeUtilityTest.cs
@@ -7,6 +7,8 @@ namespace BlazingStory.Test.Internals.Utils;
 [SetCulture("en-US")]
 public class TypeUtilityTest
 {
+    private sealed class SampleRef { }
+
     [Test]
     public void TryConvertType_RenderFragment_Test()
     {
@@ -119,6 +121,145 @@ public class TypeUtilityTest
 
         // Then
         result.IsInstanceOf<int>().Is(1024);
+    }
+
+    // The encoder emits "(null)" for any null arg value. The decoder must honour it for reference types too, not just Nullable<T>.
+    // Also pins the documented behaviour change: a user-typed literal "(null)" in a string control becomes null.
+    [Test]
+    public void TryConvertType_String_from_Null_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(string));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsTrue();
+
+        // Then
+        result.IsNull();
+    }
+
+    [Test]
+    public void TryConvertType_RenderFragment_from_Null_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(RenderFragment));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsTrue();
+
+        // Then
+        result.IsNull();
+    }
+
+    [Test]
+    public void TryConvertType_Action_from_Null_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(Action));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsTrue();
+
+        // Then
+        result.IsNull();
+    }
+
+    [Test]
+    public void TryConvertType_List_from_Null_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(List<int>));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsTrue();
+
+        // Then
+        result.IsNull();
+    }
+
+    [Test]
+    public void TryConvertType_CustomClass_from_Null_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(SampleRef));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsTrue();
+
+        // Then
+        result.IsNull();
+    }
+
+    // Collection elements must recurse through TryConvertType and a null element must round-trip back to null, not the literal "(null)".
+    [Test]
+    public void TryConvertType_ListOfString_with_NullElement_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(List<string>));
+
+        // When
+        TypeUtility.TryConvertType(target, "a,(null),c", out var result).IsTrue();
+
+        // Then
+        var list = result.IsInstanceOf<List<string>>();
+        list.Count.Is(3);
+        list[0].Is("a");
+        list[1].IsNull();
+        list[2].Is("c");
+    }
+
+    // Regression guards: "(null)" must NOT collapse non-nullable value types - the CLR cannot bind null to int/bool
+    // Catches a future "simplification" that widens the null shortcut to all types.
+    [Test]
+    public void TryConvertType_NonNullableInt_from_NullLiteral_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(int));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsFalse();
+
+        // Then
+        result.IsNull();
+    }
+
+    [Test]
+    public void TryConvertType_NonNullableBool_from_NullLiteral_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(bool));
+
+        // When
+        TypeUtility.TryConvertType(target, "(null)", out var result).IsFalse();
+
+        // Then
+        result.IsNull();
+    }
+
+    [Test]
+    public void TryConvertType_String_from_EmptyString_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(string));
+
+        // When
+        TypeUtility.TryConvertType(target, "", out var result).IsTrue();
+
+        // Then
+        result.Is("");
+    }
+
+    [Test]
+    public void TryConvertType_String_from_LiteralValue_Test()
+    {
+        // Given
+        var target = TypeUtility.ExtractTypeStructure(typeof(string));
+
+        // When
+        TypeUtility.TryConvertType(target, "Hello", out var result).IsTrue();
+
+        // Then
+        result.Is("Hello");
     }
 
     [Test]


### PR DESCRIPTION
Closes #119.

## Summary

- `PreviewFrame.ConvertParameterValueToStringAsync` encodes every `null` arg value as the literal string `"(null)"` regardless of nullability. The decoder in `TypeUtility.TryConvertType` only honoured that sentinel when `IsNullable` was `true`, and `ExtractTypeStructure` only sets `IsNullable = true` for `Nullable<T>` value types. So `string`, `RenderFragment`, `Action`, `List<T>`, and custom-class parameters round-tripped from `null` to the literal four-character string `"(null)"` - visible on first load, no user interaction required. The `List<int>` case was worse: it crashed with `ArgumentNullException` from `List<int>.Add(null)` inside `ConvertToCollection`.
- Decoder-side fix: widen the `"(null)"` sentinel to cover any reference type (`isNullable || !primaryType.IsValueType`). Encoder stays unchanged so collection elements can still distinguish `null` from `""`.
- Non-nullable value types (`int`, `bool`, enums) still cannot collapse to `null`, matching CLR semantics - guarded by tests.

### Why it was happening
Step 1: encoder always emits "(null)"
[PreviewFrame.razor:111-118](https://github.com/jsakamoto/BlazingStory/blob/main/BlazingStory/Internals/Components/Preview/PreviewFrame.razor#L111-L118) (introduced in commit [2a50f94b](https://github.com/jsakamoto/BlazingStory/commit/2a50f94b) - "Enable collection-type parameters to round-trip through the preview frame"):

```csharp
        static string ToFormattedString(object? obj) => obj switch
        {
            null => "(null)",
            IFormattable f => f.ToString(format: null, formatProvider: CultureInfo.InvariantCulture),
            _ => obj.ToString() ?? ""
        };
```
The previous fallback for non-Nullable<T> parameters was `value?.ToString() ?? ""`, so null round-tripped as an empty string. The new code emits "(null)" regardless of `TypeStructure.IsNullable`.

Step 2: decoder only undoes it for Nullable<T>
[TypeUtility.TryConvertType (TypeUtility.cs:108-121)](https://github.com/jsakamoto/BlazingStory/blob/main/BlazingStory.ToolKit/Utils/TypeUtility.cs#L108-L121):

```csharp
        if (isNullable && sourceString == "(null)")
        {
            convertedValue = null;
            return true;
        }

        else if (primaryType == typeof(string))
        {
            convertedValue = sourceString;
            return true;
        }
```

ExtractTypeStructure only sets IsNullable = true for `System.Nullable<T>` (value types). Reference types - regardless of NRT annotations - always come through with IsNullable = false. The decoder therefore falls into the `typeof(string)` branch and returns "(null)" as a literal string.

Step 3: every parameter is seeded into context.Args on load
PreviewFrame builds the iframe URL from context.Args, and context.Args is populated with default values for every parameter on initial render. So the bug fires for any string parameter on any story, without anyone touching the Controls panel.

## Behavioural trade-off

A user-typed literal `"(null)"` in a `string` control now becomes `null`. Acceptable: the wire format has always conflated empty and null for non-nullable strings, and `null` is the more conservative default.

## Test plan

- [x] First commit (`43dec6c`) adds 10 new tests in `TypeUtilityTest.cs` — 6 fail on `main`, 4 pass as regression guards. CI on this commit demonstrates the bug.
- [x] Second commit (`8c758a3`) applies the one-line predicate change in `TypeUtility.cs`. All 6 previously-failing tests pass; existing 30 `TypeUtility` tests still pass.
- [x] Full suite green: 471/471 across net8.0, net9.0, net10.0.

## Files changed

- `BlazingStory.ToolKit/Utils/TypeUtility.cs` - predicate widened, one line.
- `Tests/BlazingStory.Test/Internals/Utils/TypeUtilityTest.cs` - 10 new tests.