### PR TITLE
Fix preview frame jitter when consumer scroll-locks body

### DIFF
--- a/BlazingStory.Stories/Stories/Internal/Pages/Canvas/IFrameAutoHeight.stories.razor
+++ b/BlazingStory.Stories/Stories/Internal/Pages/Canvas/IFrameAutoHeight.stories.razor
@@ -1,0 +1,39 @@
+@attribute [Stories("Internals/Pages/Canvas/IFrameAutoHeight")]
+@inject IJSRuntime JsRuntime
+
+<Stories TComponent="object">
+
+    <Story Name="Body position fixed">
+        <Description>
+            Verifies that the canvas frame height stays stable when the page body is set to position:fixed
+            (a scroll-lock pattern used by overlay components). Click the button to toggle. The preview
+            frame should keep showing the full content; it must not shrink while the body is fixed nor jump
+            when it is unfixed.
+        </Description>
+        <Template>
+            <Stack Direction="Direction.Column">
+                <SquareButton OnClick="ToggleScrollLock" ButtonStyle="ButtonStyle.Default">
+                    @(IsLocked ? "Unfix body" : "Set body.position = fixed")
+                </SquareButton>
+                <div style="height: 600px; background: #eceff1; color: #263238; display: flex; align-items: center; justify-content: center; font-family: sans-serif; font-size: 14px;">
+                    Tall content (600px). Preview frame must remain sized to fit this while the body is fixed.
+                </div>
+            </Stack>
+        </Template>
+    </Story>
+
+</Stories>
+
+@code
+{
+    private bool IsLocked;
+
+    private async Task ToggleScrollLock()
+    {
+        IsLocked = !IsLocked;
+        var js = IsLocked
+            ? "document.body.style.position='fixed';document.body.style.top='0';document.body.style.left='0';document.body.style.right='0';"
+            : "document.body.style.position='';document.body.style.top='';document.body.style.left='';document.body.style.right='';";
+        await JsRuntime.InvokeVoidAsync("eval", js);
+    }
+}

--- a/BlazingStory/Internals/Pages/IFrame.razor.js
+++ b/BlazingStory/Internals/Pages/IFrame.razor.js
@@ -73,21 +73,24 @@ export const initializeCanvasFrame = () => {
         }, location.origin);
     });
     if (htmlElement) {
-        const resizeObserver = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                const height = Math.ceil(entry.target.getBoundingClientRect().height);
-                const iframeElement = getParentFrame();
-                if (iframeElement) {
-                    const event = new CustomEvent('frameheightchange', {
-                        cancelable: false,
-                        bubbles: true,
-                        detail: { height }
-                    });
-                    iframeElement.dispatchEvent(event);
-                }
+        const measureHeight = () => {
+            const style = wnd.getComputedStyle(body);
+            const marginTop = parseFloat(style.marginTop) || 0;
+            const marginBottom = parseFloat(style.marginBottom) || 0;
+            return Math.ceil(body.scrollHeight + marginTop + marginBottom);
+        };
+        const resizeObserver = new ResizeObserver(() => {
+            const iframeElement = getParentFrame();
+            if (iframeElement) {
+                const event = new CustomEvent('frameheightchange', {
+                    cancelable: false,
+                    bubbles: true,
+                    detail: { height: measureHeight() }
+                });
+                iframeElement.dispatchEvent(event);
             }
         });
-        resizeObserver.observe(htmlElement);
+        resizeObserver.observe(body);
     }
     wnd.BlazingStory = wnd.BlazingStory || {};
     wnd.BlazingStory.canvasFrameInitialized = true;

--- a/BlazingStory/Internals/Pages/IFrame.razor.ts
+++ b/BlazingStory/Internals/Pages/IFrame.razor.ts
@@ -107,21 +107,27 @@ export const initializeCanvasFrame = () => {
     });
 
     if (htmlElement) {
-        const resizeObserver = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                const height = Math.ceil(entry.target.getBoundingClientRect().height);
-                const iframeElement = getParentFrame();
-                if (iframeElement) {
-                    const event = new CustomEvent('frameheightchange', {
-                        cancelable: false,
-                        bubbles: true,
-                        detail: { height }
-                    });
-                    iframeElement.dispatchEvent(event);
-                }
+        // Measure body.scrollHeight, not <html>'s box: scroll-lock implementations that set
+        // body.position = 'fixed' collapse <html> to 0, but body.scrollHeight is unaffected.
+        const measureHeight = () => {
+            const style = wnd.getComputedStyle(body);
+            const marginTop = parseFloat(style.marginTop) || 0;
+            const marginBottom = parseFloat(style.marginBottom) || 0;
+            return Math.ceil(body.scrollHeight + marginTop + marginBottom);
+        };
+
+        const resizeObserver = new ResizeObserver(() => {
+            const iframeElement = getParentFrame();
+            if (iframeElement) {
+                const event = new CustomEvent('frameheightchange', {
+                    cancelable: false,
+                    bubbles: true,
+                    detail: { height: measureHeight() }
+                });
+                iframeElement.dispatchEvent(event);
             }
         });
-        resizeObserver.observe(htmlElement);
+        resizeObserver.observe(body);
     }
 
     wnd.BlazingStory = wnd.BlazingStory || {};


### PR DESCRIPTION
Fixes #116 

The preview frame visibly shrinks and restores whenever a story opens an overlay that scroll-locks the page by setting `body.position = 'fixed'` (popovers, dropdowns, dialogs in common component libraries). The ResizeObserver in the canvas frame watches `<html>` and reports its bounding height, but setting `body.position = 'fixed'` removes body from `<html>`'s flow and collapses `<html>` to 0. That 0 is forwarded as the intended frame height, so the Docs page sets `height: 0px` on the viewport - the iframe shrinks on overlay open and jumps back on close.

This PR change switches the observation target from `<html>` to `<body>` and measures `body.scrollHeight + vertical margins` instead of `<html>`'s rect. `body.scrollHeight` is unaffected by `body.position` and by fixed-positioned descendants (popovers, dialogs render out of normal flow), so the reported height stays stable across overlay open/close cycles. The margin addition preserves the previous behaviour where the frame height included body's CSS margins.

## Repro steps

Reset branch to the first commit and see the demo story I added to visualise the problem. Then pull the other commit and see it fixed.

`BlazingStory.Stories/Stories/Internal/Pages/Canvas/IFrameAutoHeight.stories.razor` - a one-button interactive story that toggles `body.position = 'fixed'` on the canvas body and renders 600px of content. Open it via the Docs view to see the preview-frame-viewport height jitter.