### PR TITLE
Show parameter summaries as a tooltip in the controls panel

### DIFF
--- a/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor
+++ b/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor
@@ -33,7 +33,7 @@
                     @* The Description column is rendered in the docs view only, where there is room
                        for it. Exposing the same summary as a tooltip keeps it reachable in the
                        canvas view, which is where the controls are actually manipulated. *@
-                    <td class="name" title="@parameter.Summary">
+                    <td class="name" title="@parameter.Summary.Value">
                         <span>@parameter.Name</span>
                         @if (parameter.Required)
                         {

--- a/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor
+++ b/BlazingStory.Addons.BuiltIns/Panel/Controls/ControlsPanel.razor
@@ -30,7 +30,10 @@
                 var key = this.GetKey(parameter);
                 <tr @key="key">
 
-                    <td class="name">
+                    @* The Description column is rendered in the docs view only, where there is room
+                       for it. Exposing the same summary as a tooltip keeps it reachable in the
+                       canvas view, which is where the controls are actually manipulated. *@
+                    <td class="name" title="@parameter.Summary">
                         <span>@parameter.Name</span>
                         @if (parameter.Required)
                         {


### PR DESCRIPTION
**TL;DR** - one attribute: the parameter's XML summary is now a `title` tooltip on the control's name cell, so descriptions are reachable in the canvas view, not just in docs. No layout change, no new setting, docs view untouched.

<img width="629" height="214" alt="screen" src="https://github.com/user-attachments/assets/6fdeb26b-f184-4ea5-98dd-574e24059e9d" />

<!-- SCREENSHOT -->

### Why

The Controls panel renders the Description column only in the docs view:

```csharp
private bool ShowDetails => this.ViewMode == ViewMode.Docs;
```

That is the right call for layout - with the addon panel docked to the right there simply is not room for another column. But it means that while someone is actually manipulating a control, which happens in the **canvas**, the description of what that parameter does is not visible anywhere without switching tabs.

The information is not missing, only unrendered: `parameter.Summary` is populated in canvas view too.

### What changed

```razor
<td class="name" title="@parameter.Summary">
```

Four lines including a comment. This mirrors the `title` the same file already puts on the required marker (`<span class="required" title="Required">*</span>`), so it is consistent with the existing style rather than introducing a new pattern.

- Docs view: unchanged, still shows the full Description and Default columns.
- Canvas view: hovering a parameter name shows its summary.
- No new configuration surface, no CSS, no layout shift.

### Alternatives considered

A dedicated tooltip component would handle long summaries and markdown better, and would be worth it if the summaries get rich. The plain `title` gets most of the value for one attribute, so it seemed the right first step - happy to take it further if you would prefer that shape.

### Verification

Built the packages locally and ran them against a real storybook (a Blazor WebAssembly wrapper library with XML-documented parameters). The tooltip shows the expected summary in canvas view, and the docs view is unaffected.

Closes #132