### PR TITLE
Do not dereference a null preview-frame container

### DIFF
--- a/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.js
+++ b/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.js
@@ -14,6 +14,8 @@ const waitFor = async (arg) => {
     }
 };
 const getIFrame = async (container) => {
+    if (!container)
+        return null;
     return await waitFor({
         predecate: () => {
             const iframe = container.querySelector('iframe');

--- a/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.ts
+++ b/BlazingStory/Internals/Components/Preview/PreviewFrame.razor.ts
@@ -18,7 +18,13 @@ const waitFor = async <T>(arg: { predecate: () => false | T, maxRetryCount?: num
     }
 }
 
-const getIFrame = async (container: HTMLElement) => {
+const getIFrame = async (container: HTMLElement | null) => {
+    // The container is an element reference marshalled from .NET. A pooled preview frame can be
+    // recycled or unmounted before the call lands, in which case it arrives here as null and
+    // "container.querySelector" throws out of the retry loop, surfacing as an unhandled exception
+    // rendering PreviewFrame. Returning early is right rather than retrying: a container that is
+    // already gone is not going to come back, so waiting would only delay the same answer.
+    if (!container) return null;
     return await waitFor({
         predecate: () => {
             const iframe = container.querySelector('iframe');


### PR DESCRIPTION
### Problem

`getIFrame` receives an element reference marshalled from .NET. When a pooled preview frame is recycled or unmounted before the call lands, that reference arrives as `null`, and `container.querySelector('iframe')` throws from inside the `waitFor` retry loop.

It surfaces as an unhandled exception rendering `PreviewFrame`:

```
Unhandled exception rendering component: Cannot read properties of null (reading 'querySelector')
TypeError: Cannot read properties of null (reading 'querySelector')
    at Object.predecate (PreviewFrame.razor.js:19:38)
    at waitFor (PreviewFrame.razor.js:7:28)
    at getIFrame (PreviewFrame.razor.js:17:18)
    at Module.getFrameHeight (PreviewFrame.razor.js:51:26)
   at BlazingStory.Internals.Components.Preview.PreviewFrame.OnPreviewIFrameAttached()
   at BlazingStory.Internals.Components.Layouts.PooledIFrame.OnAfterRenderAsync(Boolean firstRender)
```

### Reproduction

Open a story directly by URL (`/?path=/story/<id>`) in a published storybook. The story canvas still renders, but the console fills with the exception above. It is intermittent and depends on how quickly the pooled iframe is attached relative to the height measurement.

### Fix

Return `null` early when the container is absent.

Returning early rather than retrying is deliberate: a container that is already gone will not come back, so the 500 retries would only delay the same answer by five seconds.

All four call sites already handle a `null` result (`result?.`, `if (!result) return`), so none of them change.

### Notes

- The parameter type is widened to `HTMLElement | null` to reflect what actually arrives at runtime.
- The committed `.js` is updated to match. I verified with `tsc` that the compiler emits exactly this output for the changed function; I hand-applied it rather than committing a full `tsc` run because the compiler rewrites every `.js` in the project from CRLF to LF, which would have buried the change in unrelated diffs.