### PR TITLE
Fix runaway canvas height when host CSS ties body height to the viewport

### DIFF
--- a/BlazingStory/Internals/Pages/IFrame.razor.js
+++ b/BlazingStory/Internals/Pages/IFrame.razor.js
@@ -73,12 +73,38 @@ export const initializeCanvasFrame = () => {
         }, location.origin);
     });
     if (htmlElement) {
+        const captureProperty = (element, property) => ({
+            value: element.style.getPropertyValue(property),
+            priority: element.style.getPropertyPriority(property)
+        });
+        const restoreProperty = (element, property, saved) => {
+            if (saved.value)
+                element.style.setProperty(property, saved.value, saved.priority);
+            else
+                element.style.removeProperty(property);
+        };
         const measureHeight = () => {
-            const style = wnd.getComputedStyle(body);
-            const marginTop = parseFloat(style.marginTop) || 0;
-            const marginBottom = parseFloat(style.marginBottom) || 0;
-            const zoom = parseFloat(style.getPropertyValue('--bs-zoom')) || 1;
-            return Math.ceil((body.scrollHeight + marginTop + marginBottom) * zoom);
+            const savedHtmlHeight = captureProperty(htmlElement, "height");
+            const savedHtmlMinHeight = captureProperty(htmlElement, "min-height");
+            const savedBodyHeight = captureProperty(body, "height");
+            const savedBodyMinHeight = captureProperty(body, "min-height");
+            htmlElement.style.setProperty("height", "auto", "important");
+            htmlElement.style.setProperty("min-height", "0", "important");
+            body.style.setProperty("height", "auto", "important");
+            body.style.setProperty("min-height", "0", "important");
+            try {
+                const style = wnd.getComputedStyle(body);
+                const marginTop = parseFloat(style.marginTop) || 0;
+                const marginBottom = parseFloat(style.marginBottom) || 0;
+                const zoom = parseFloat(style.getPropertyValue('--bs-zoom')) || 1;
+                return Math.ceil((body.scrollHeight + marginTop + marginBottom) * zoom);
+            }
+            finally {
+                restoreProperty(htmlElement, "height", savedHtmlHeight);
+                restoreProperty(htmlElement, "min-height", savedHtmlMinHeight);
+                restoreProperty(body, "height", savedBodyHeight);
+                restoreProperty(body, "min-height", savedBodyMinHeight);
+            }
         };
         const resizeObserver = new ResizeObserver(() => {
             const iframeElement = getParentFrame();

--- a/BlazingStory/Internals/Pages/IFrame.razor.ts
+++ b/BlazingStory/Internals/Pages/IFrame.razor.ts
@@ -108,12 +108,49 @@ export const initializeCanvasFrame = () => {
     if (htmlElement) {
         // Measure body.scrollHeight, not <html>'s box: scroll-lock implementations that set
         // body.position = 'fixed' collapse <html> to 0, but body.scrollHeight is unaffected.
+        //
+        // This frame's own "viewport" is the outer <iframe>, whose height is set by the host from
+        // the value this function returns (see PreviewFrame.razor.ts / StoryPreview.razor). A host
+        // stylesheet that ties <html> or <body> to that viewport - `height: 100%`, `min-height:
+        // 100vh`, etc., on either element, however it gets there - turns that into a feedback loop:
+        // each measurement includes the height just assigned by the *previous* one, so the reported
+        // height (plus the body margin added below) grows every cycle instead of settling.
+        // Chasing every such rule (inline or stylesheet, vh or %) is a losing game, so instead
+        // neutralize both elements for the instant of the measurement - a synchronous read with no
+        // intervening layout/paint, so there is no visible flicker - which makes scrollHeight reflect
+        // only the natural content height regardless of what the host's CSS ties to the viewport.
+        const captureProperty = (element: HTMLElement, property: string) => ({
+            value: element.style.getPropertyValue(property),
+            priority: element.style.getPropertyPriority(property)
+        });
+
+        const restoreProperty = (element: HTMLElement, property: string, saved: { value: string, priority: string }) => {
+            if (saved.value) element.style.setProperty(property, saved.value, saved.priority);
+            else element.style.removeProperty(property);
+        };
+
         const measureHeight = () => {
-            const style = wnd.getComputedStyle(body);
-            const marginTop = parseFloat(style.marginTop) || 0;
-            const marginBottom = parseFloat(style.marginBottom) || 0;
-            const zoom = parseFloat(style.getPropertyValue('--bs-zoom')) || 1;
-            return Math.ceil((body.scrollHeight + marginTop + marginBottom) * zoom);
+            const savedHtmlHeight = captureProperty(htmlElement, "height");
+            const savedHtmlMinHeight = captureProperty(htmlElement, "min-height");
+            const savedBodyHeight = captureProperty(body, "height");
+            const savedBodyMinHeight = captureProperty(body, "min-height");
+            htmlElement.style.setProperty("height", "auto", "important");
+            htmlElement.style.setProperty("min-height", "0", "important");
+            body.style.setProperty("height", "auto", "important");
+            body.style.setProperty("min-height", "0", "important");
+
+            try {
+                const style = wnd.getComputedStyle(body);
+                const marginTop = parseFloat(style.marginTop) || 0;
+                const marginBottom = parseFloat(style.marginBottom) || 0;
+                const zoom = parseFloat(style.getPropertyValue('--bs-zoom')) || 1;
+                return Math.ceil((body.scrollHeight + marginTop + marginBottom) * zoom);
+            } finally {
+                restoreProperty(htmlElement, "height", savedHtmlHeight);
+                restoreProperty(htmlElement, "min-height", savedHtmlMinHeight);
+                restoreProperty(body, "height", savedBodyHeight);
+                restoreProperty(body, "min-height", savedBodyMinHeight);
+            }
         };
 
         const resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
### Problem

The canvas/Docs preview iframe's height is set by the host from `measureHeight()`'s return value (`body.scrollHeight` + margins). If the hosted app's own CSS ties `<html>` or `<body>` height to the viewport - e.g. `height: 100%` or `min-height: 100vh`, via a stylesheet rule rather than an inline style - this creates a feedback loop: each measurement includes the height that was just assigned by the *previous* one, so the reported height (and the iframe height set from it) grows every cycle instead of settling.

There's already a guard for exactly this class of bug (`if (body.style.minHeight === "100vh") body.style.removeProperty("min-height")`), but it only catches that one literal inline value - not a rule coming from a stylesheet, not `height`, and not `100%`. A host with `html, body { height: 100%; }` in its global stylesheet defeats it entirely.

### Reproduction

Host an app whose global CSS includes `html, body { height: 100%; }` (or any stylesheet-level rule tying either element to the viewport), and open a Docs page for a component whose story renders under that CSS. The canvas box grows on every render cycle instead of settling to the content's natural height, and the console shows the canvas iframe's WASM runtime rebooting repeatedly.

### Fix

Neutralize `height`/`min-height` on both `<html>` and `<body>` for the instant of the measurement only (synchronous read, no intervening layout/paint - no visible flicker), so `scrollHeight` reflects the natural content height regardless of what the host ties to the viewport, then restore immediately. This fixes the loop at its source rather than chasing every way a host's CSS can tie height to the viewport.

### Notes

- Verified against a real host app with `html, body { height: 100%; }` in its global CSS: canvas height held stable across 12+ seconds of polling (previously cycled 155->203->222->417px with the canvas iframe's WASM runtime rebooting repeatedly); only one clean boot now.
- The committed `.js` is the output of the project's own `tsc -p tsconfig.json`, verified to touch only this function (a full project-wide `tsc` run also "fixed" several pre-existing stale `.js` companions out of sync with their own `.ts` - unrelated to this change, left untouched).